### PR TITLE
Add Outlook appointment send notification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.DS_Store

--- a/Manifest.xml
+++ b/Manifest.xml
@@ -207,28 +207,34 @@
 
             <!-- NEW FOR SSO GENERIC TEST | ROBERTO TEST  -->
              <!-- </ExtensionPoint>
-						<ExtensionPoint xsi:type="MessageComposeCommandSurface">
-						  <OfficeTab id="TabDefault">
-							<Group id="profileGroup">
-							  <Label resid="GetProfileGroup.Label"/>
-							  <Control xsi:type="Button" id="getProfileButton">
-								<Label resid="GetProfileButton.Label"/>
-								<Supertip>
-								  <Title resid="GetProfileButton.Label"/>
-								  <Description resid="GetProfileButton.Tooltip"/>
-								</Supertip>
-								<Icon>
-								  <bt:Image size="16" resid="Icon.16x16"/>
-								  <bt:Image size="32" resid="Icon.32x32"/>
-								  <bt:Image size="80" resid="Icon.80x80"/>
-								</Icon>
-								<Action xsi:type="ExecuteFunction">
-								  <FunctionName>getUserProfile</FunctionName>
-								</Action>
-							  </Control> 
-							</Group>
-						  </OfficeTab>-->
-						</ExtensionPoint>
+                                                <ExtensionPoint xsi:type="MessageComposeCommandSurface">
+                                                  <OfficeTab id="TabDefault">
+                                                        <Group id="profileGroup">
+                                                          <Label resid="GetProfileGroup.Label"/>
+                                                          <Control xsi:type="Button" id="getProfileButton">
+                                                                <Label resid="GetProfileButton.Label"/>
+                                                                <Supertip>
+                                                                  <Title resid="GetProfileButton.Label"/>
+                                                                  <Description resid="GetProfileButton.Tooltip"/>
+                                                                </Supertip>
+                                                                <Icon>
+                                                                  <bt:Image size="16" resid="Icon.16x16"/>
+                                                                  <bt:Image size="32" resid="Icon.32x32"/>
+                                                                  <bt:Image size="80" resid="Icon.80x80"/>
+                                                                </Icon>
+                                                                <Action xsi:type="ExecuteFunction">
+                                                                  <FunctionName>getUserProfile</FunctionName>
+                                                                </Action>
+                                                          </Control>
+                                                        </Group>
+                                                  </OfficeTab>-->
+                                                </ExtensionPoint>
+                                                <ExtensionPoint xsi:type="LaunchEvent">
+                                                  <SourceLocation resid="Commands.Url"/>
+                                                  <LaunchEvents>
+                                                    <LaunchEvent Type="OnAppointmentSend" FunctionName="onAppointmentSendHandler"/>
+                                                  </LaunchEvents>
+                                                </ExtensionPoint>
           </DesktopFormFactor>
         </Host>
       </Hosts>

--- a/src/commands/commands.html
+++ b/src/commands/commands.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Commands</title>
+    <script src="https://appsforoffice.microsoft.com/lib/1/hosted/office.js"></script>
+  </head>
+  <body>
+  </body>
+</html>

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -1,0 +1,44 @@
+/* global Office */
+
+const notificationId = "smartMeetingRoomStatus";
+
+function getNotificationOptions() {
+  return {
+    type: Office.MailboxEnums.ItemNotificationMessageType.InformationalMessage,
+    message: "Smart Meeting Room is now working on your request",
+    icon: "Icon.16x16",
+    persistent: false,
+  };
+}
+
+function completeEvent(event) {
+  event.completed({ allowEvent: true });
+}
+
+function showStatusMessage(event) {
+  const options = getNotificationOptions();
+
+  Office.context.mailbox.item.notificationMessages.replaceAsync(
+    notificationId,
+    options,
+    (result) => {
+      if (result.status === Office.AsyncResultStatus.Succeeded) {
+        completeEvent(event);
+      } else {
+        Office.context.mailbox.item.notificationMessages.addAsync(notificationId, options, () =>
+          completeEvent(event)
+        );
+      }
+    }
+  );
+}
+
+function onAppointmentSendHandler(event) {
+  showStatusMessage(event);
+}
+
+Office.onReady(() => {
+  Office.actions.associate("onAppointmentSendHandler", onAppointmentSendHandler);
+});
+
+export { onAppointmentSendHandler };


### PR DESCRIPTION
## Summary
- register the OnAppointmentSend event in the manifest to trigger command runtime logic when appointments are sent
- show a Smart Meeting Room status notification during send handling so users know the request is being processed
- add a gitignore to exclude local build artifacts

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c878b258d4832b9738444aae631deb